### PR TITLE
Update for ubuntu 24.04

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -55,6 +55,23 @@ To install the `lab` tool on your local machine, follow these steps:
 pip install .
 ```
 
+### 3a. Install Ansible Core and Ansible
+
+```bash
+# Install Ansible Core
+pip install ansible-core
+
+# Install Ansible
+pip install ansible
+```
+
+### 3b. Install Ansible Digital Colection
+
+```bash
+# Install Digital Ocent Ansible Collection
+ansible-galaxy collection install community.digitalocean
+```
+
 ### 4. Setup environment files
 
 The setup of the lab environment relies on variables specified in the `.env` and `.setup.env` files. We provide skeleton files that you can reference to set up the environment. Begin by copying these example files:

--- a/setup/create_droplet.yml
+++ b/setup/create_droplet.yml
@@ -9,7 +9,7 @@
     - name: "droplet_image"
       prompt: "Enter the droplet image"
       private: false
-      default: "ubuntu-22-04-x64"
+      default: "ubuntu-24-04-x64"
 
     - name: "droplet_size"
       prompt: "Enter the droplet size"

--- a/setup/setup_droplet.yml
+++ b/setup/setup_droplet.yml
@@ -2,7 +2,7 @@
 #### Bootstrap cookbook-lab-droplet
 - name: Bootstrap cookbook-lab-droplet
   hosts: "{{ lookup('ansible.builtin.env', 'DO_DROPLET_NAME') }}"
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Wait for connection to cookbook-lab-droplet
       ansible.builtin.wait_for_connection:
@@ -27,6 +27,8 @@
           - python3-setuptools
           - apache2-utils
           - git
+          - curl
+          - gnupg
           # - bpfcc-tools
           # - linux-headers-$(uname -r)
         state: latest
@@ -37,26 +39,60 @@
       register: apt_install
       until: apt_install is succeeded
 
-    - name: Download Docker
-      ansible.builtin.get_url:
-        url: https://get.docker.com
-        dest: /tmp/get-docker.sh
+    - name: Create Keyrings directory
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
         mode: "0755"
 
-    - name: Install Docker
-      ansible.builtin.command: bash -c /tmp/get-docker.sh
-      register: docker_install
-      retries: 3
-      delay: 10
-      changed_when: docker_install.rc != 0
+    - name: Download Docker GPG key
+      ansible.builtin.get_url:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        dest: /etc/apt/keyrings/docker.asc
+        mode: "0644"
+        force: true
 
-    - name: Install Python packages
-      ansible.builtin.pip:
-        name:
-          - docker
+    - name: Set permissions on keyring
+      ansible.builtin.file:
+        path: /etc/apt/keyrings/docker.asc
+        mode: '0644'
+
+    - name: Add Docker APT Repository
+      ansible.builtin.apt_repository:
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        state: present
+        filename: docker
+        update_cache: true
+
+    - name: Create Docker config directory
+      ansible.builtin.file:
+        path: /etc/docker
+        state: directory
+        mode: "0755"
+
+    - name: Create Docker to use overlay2 storage driver
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        content: |
+         {
+           "storage-driver": "overlay2"
+         }
+        mode: "0644"  
+  
+    - name: Install docker and python docker module
+      ansible.builtin.apt:
+        pkg:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - python3-docker
         state: latest
       tags:
         - skip_ansible_lint
+      retries: 3
+      delay: 10
+      register: apt_install
+      until: apt_install is succeeded
 
     - name: Download Miniconda python environment
       ansible.builtin.get_url:


### PR DESCRIPTION
Changes to support using a Ubuntu 24.04 Droplet.

- Edit Documentation
- Add reminder to install ansible-core and ansible first.
- Add step to install community.dreamhost collection.
- Changes
- Modify how docker is installed to follow best practice
- Create docker config file to use overlay2 instead of overlayfs for the storage driver.
  (This was preventing docker from importing the Juniper cRPD image).
- Install python docker package from apt rather than pip
- Change defaults droplet from 22.04 to 24.04